### PR TITLE
Limit logged IP address to 250 (filterable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features
 - Handles server behind reverse proxy
 - It is possible to whitelist IPs using a filter. But you probably shouldn't. :-)
 
-Translations: Bulgarian, Brazilian Portuguese, Catalan, Chinese (Traditional), Czech, Dutch, Finnish, French, German, Hungarian, Norwegian, Persian, Romanian, Russian, Spanish, Swedish, Turkish
+Translations: Bulgarian, Brazilian Portuguese, Catalan, Chinese (Traditional), Czech, Dutch, Finnish, French, German, Hungarian, Italian, Norwegian, Persian, Romanian, Russian, Spanish, Swedish, Turkish
 
 ## Installation
 
@@ -75,3 +75,20 @@ Either wait, or:
 If you have ftp / ssh access to the site rename the file `wp-content/plugins/limit-login-attempts/limit-login-attempts.php` to deactivate the plugin.
 
 If you have access to the database (for example through phpMyAdmin) you can clear the `limit_login_lockouts` option in the wordpress options table. In a default setup this would work: `UPDATE wp_options SET option_value = '' WHERE option_name = 'limit_login_lockouts'`.
+
+*How many IPs are logged?*
+
+By default 250.
+
+That said, there is now a filter which allows you to do it: "limit_login_log_max_ips".
+
+Setting the value to 0 means no limits.
+
+Example:
+
+```php
+function limit_login_log_unlimited_ips($max_ips) {
+	 return 0;
+}
+add_filter('limit_login_log_max_ips', 'limit_login_log_unlimited_ips', 10, 2);
+```

--- a/limit-login-attempts-ng.php
+++ b/limit-login-attempts-ng.php
@@ -599,6 +599,19 @@ function limit_login_notify_log($user) {
 		$log[$ip] = array($user => 1);
 	}
 
+	/**
+	 * Filters how many IP are stored in the log list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int     $max_ips The maximum number of IP address to keeep in the logs.
+	 *                         Default 250. 0 means unlimited
+	 */
+	$max_log_size = apply_filters('limit_login_log_max_ips', 250);
+	if ($max_log_size !== 0 && count($log) > $max_log_size) {
+		array_shift($log);
+	}
+
 	if ($option === false) {
 		add_option('limit_login_logged', $log, '', 'no'); /* no autoload */
 	} else {

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ Features
 * Handles server behind reverse proxy
 * It is possible to whitelist IPs using a filter. But you probably shouldn't. :-)
 
-Translations: Bulgarian, Brazilian Portuguese, Catalan, Chinese (Traditional), Czech, Dutch, Finnish, French, German, Hungarian, Norwegian, Persian, Romanian, Russian, Spanish, Swedish, Turkish
+Translations: Bulgarian, Brazilian Portuguese, Catalan, Chinese (Traditional), Czech, Dutch, Finnish, French, German, Hungarian, Italian, Norwegian, Persian, Romanian, Russian, Spanish, Swedish, Turkish
 
 Plugin uses standard actions and filters only.
 
@@ -76,3 +76,17 @@ If you know how to edit / add to PHP files you can use the IP whitelist function
 If you have ftp / ssh access to the site rename the file "wp-content/plugins/limit-login-attempts/limit-login-attempts.php" to deactivate the plugin.
 
 If you have access to the database (for example through phpMyAdmin) you can clear the limit_login_lockouts option in the wordpress options table. In a default setup this would work: "UPDATE wp_options SET option_value = '' WHERE option_name = 'limit_login_lockouts'"
+
+= How many IPs are logged? =
+
+By default 250.
+
+That said, there is now a filter which allows you to do it: "limit_login_log_max_ips".
+
+Setting the value to 0 means no limits.
+
+Example:
+function limit_login_log_unlimited_ips($max_ips) {
+	 return 0;
+}
+add_filter('limit_login_log_max_ips', 'limit_login_log_unlimited_ips', 10, 2);


### PR DESCRIPTION
Limit logged IP address to 250 (filterable).
The filter `limit_login_log_max_ips` allow to change that value or to keep all the logged IP setting it to `0`.