### PR TITLE
Styling of the danger buttons

### DIFF
--- a/limit-login-attempts-ng.php
+++ b/limit-login-attempts-ng.php
@@ -1167,7 +1167,7 @@ function limit_login_option_page()	{
 			<style media="screen">
 			.limit-login-log th { font-weight: bold; }
 			.limit-login-log td, .limit-login-log th { padding: 1px 5px 1px 5px; }
-			td.limit-login-ip {	font-family:	"Courier New", Courier, monospace; vertical-align: top;	}
+			td.limit-login-ip { font-family: "Courier New", Courier, monospace; vertical-align: top; }
 			td.limit-login-max { width: 100%; }
 			.button.button-danger { background-color: indianred; color: white; margin-top: -5px; }
 			</style>

--- a/limit-login-attempts-ng.php
+++ b/limit-login-attempts-ng.php
@@ -1149,17 +1149,9 @@ function limit_login_option_page()	{
 
 				<input type="hidden" value="true" name="clear_log">
 				<p class="submit">
-					<input name="submit" class="button button-secondary" value="<?php esc_html_e('Clear Log','limit-login-attempts'); ?>" type="submit">
+					<input name="submit" class="button button-danger" value="<?php esc_html_e('Clear Log','limit-login-attempts'); ?>" type="submit">
 				</p>
 			</form>
-
-			<style media="screen">
-			.limit-login-log th { font-weight: bold; }
-			.limit-login-log td, .limit-login-log th { padding: 1px 5px 1px 5px; }
-			td.limit-login-ip {	font-family:	"Courier New", Courier, monospace; vertical-align: top;	}
-			td.limit-login-max { width: 100%; }
-			.button.button-danger { background-color: indianred; color: white; margin-top: -5px; }
-			</style>
 
 			<div class="limit-login-log">
 			<table class="form-table">
@@ -1169,6 +1161,18 @@ function limit_login_option_page()	{
 
 			<?php
 		} /* if showing $log */
+
+		if (($lockouts_total > 0) || ($lockouts_now > 0) || (is_array($log) && count($log) > 0)) {
+			?>
+			<style media="screen">
+			.limit-login-log th { font-weight: bold; }
+			.limit-login-log td, .limit-login-log th { padding: 1px 5px 1px 5px; }
+			td.limit-login-ip {	font-family:	"Courier New", Courier, monospace; vertical-align: top;	}
+			td.limit-login-max { width: 100%; }
+			.button.button-danger { background-color: indianred; color: white; margin-top: -5px; }
+			</style>
+			<?php	
+		}
 		?>
 
 	</div>

--- a/limit-login-attempts-ng.php
+++ b/limit-login-attempts-ng.php
@@ -1149,7 +1149,7 @@ function limit_login_option_page()	{
 
 				<input type="hidden" value="true" name="clear_log">
 				<p class="submit">
-					<input name="submit" class="button button-danger" value="<?php esc_html_e('Clear Log','limit-login-attempts'); ?>" type="submit">
+					<input name="submit" class="button button-secondary" value="<?php esc_html_e('Clear Log','limit-login-attempts'); ?>" type="submit">
 				</p>
 			</form>
 
@@ -1162,16 +1162,22 @@ function limit_login_option_page()	{
 			<?php
 		} /* if showing $log */
 
-		if (($lockouts_total > 0) || ($lockouts_now > 0) || (is_array($log) && count($log) > 0)) {
+		if (($lockouts_total > 0) || ($lockouts_now > 0)) {
+			?>
+			<style media="screen">
+			.button.button-danger { background-color: indianred; color: white; margin-top: -5px; }
+			</style>
+			<?php
+		}
+		if (is_array($log) && count($log) > 0) {
 			?>
 			<style media="screen">
 			.limit-login-log th { font-weight: bold; }
 			.limit-login-log td, .limit-login-log th { padding: 1px 5px 1px 5px; }
 			td.limit-login-ip { font-family: "Courier New", Courier, monospace; vertical-align: top; }
 			td.limit-login-max { width: 100%; }
-			.button.button-danger { background-color: indianred; color: white; margin-top: -5px; }
 			</style>
-			<?php	
+			<?php
 		}
 		?>
 


### PR DESCRIPTION
Created this PR because of [the discussion here](https://github.com/xxsimoxx/limit-login-attempts-ng/pull/10#issuecomment-3159804127).
Added class `button-danger` to the "Clear Log" button as well.
Relocated CSS so that styling is applied to all "danger" buttons.

Instead of relocating whole CSS block we could also consider ONLY doing this for the button styling. 
If we do that, the table styling is only applied in case there's a log.